### PR TITLE
feat: add dark and light theme switch support

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -212,7 +212,7 @@ async function writeTheme(
 
 const start = performance.now();
 await Promise.all(
-  flavorEntries.flatMap(([identifier, flavor]) =>
+  flavorEntries.map(([identifier, flavor]) =>
     generateVariants(identifier, flavor)
   ),
 );

--- a/build.ts
+++ b/build.ts
@@ -31,7 +31,7 @@ const accents = [
 ] as const;
 
 async function makeThemeObject(
-  name: string,
+  identifier: string,
   accent: AccentName,
   palette: CatppuccinFlavor,
   autoTheme: boolean,
@@ -52,7 +52,7 @@ async function makeThemeObject(
     colorScheme = "auto";
   }
 
-  const themeName = `catppuccin-${name}-${accent}`;
+  const themeName = `catppuccin-${identifier}-${accent}`;
   const encodedName = new TextEncoder().encode(themeName);
   return {
     manifest_version: 2,
@@ -64,7 +64,7 @@ async function makeThemeObject(
         strict_min_version: "60.0",
       },
     },
-    description: `Soothing pastel theme for Thunderbird - ${titleCase(name)} ${
+    description: `Soothing pastel theme for Thunderbird - ${titleCase(palette.name)} ${
       titleCase(accent)
     }`,
     icons: {
@@ -178,15 +178,15 @@ async function getColors(
 }
 
 async function generateVariants(
-  name: string,
+  identifier: string,
   flavor: CatppuccinFlavor,
 ) {
   for (const accent of accents) {
-    const theme = await makeThemeObject(name, accent, flavor, false);
-    const autoTheme = await makeThemeObject(name, accent, flavor, true);
-    const fileName = `${name}-${accent}.xpi`;
-    writeTheme(fileName, theme, `./themes/default/${name}`);
-    writeTheme(fileName, autoTheme, `./themes/auto/${name}`);
+    const theme = await makeThemeObject(identifier, accent, flavor, false);
+    const autoTheme = await makeThemeObject(identifier, accent, flavor, true);
+    const fileName = `${identifier}-${accent}.xpi`;
+    writeTheme(fileName, theme, `./themes/default/${identifier}`);
+    writeTheme(fileName, autoTheme, `./themes/auto/${identifier}`);
   }
 }
 
@@ -216,7 +216,7 @@ async function writeTheme(
 
 const start = performance.now();
 await Promise.all(
-  flavorEntries.map(([name, flavor]) => generateVariants(name, flavor)),
+  flavorEntries.map(([identifier, flavor]) => generateVariants(identifier, flavor)),
 );
 
 console.log("Built in", performance.now() - start, "ms");

--- a/build.ts
+++ b/build.ts
@@ -6,7 +6,7 @@ import {
   flavors,
 } from "jsr:@catppuccin/palette@1.7.1";
 import { JSZip } from "https://deno.land/x/jszip@0.11.0/mod.ts";
-import * as uuid from "https://deno.land/std@0.207.0/uuid/mod.ts";
+import * as uuid from "jsr:@std/uuid@1.0.7";
 
 // Allows for the UUIDs to be "seeded" and therefore reproducible
 // DO NOT CHANGE

--- a/build.ts
+++ b/build.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env
 import {
-  AlphaColor,
-  Color,
-  Labels,
-  variants,
-} from "npm:@catppuccin/palette@0.1.5";
+  CatppuccinFlavor,
+  flavorEntries,
+  flavors,
+} from "https://deno.land/x/catppuccin@v1.7.1/mod.ts";
 import { titleCase } from "https://deno.land/x/case@2.2.0/mod.ts";
 import { JSZip } from "https://deno.land/x/jszip@0.11.0/mod.ts";
 import * as uuid from "https://deno.land/std@0.207.0/uuid/mod.ts";
@@ -32,11 +31,18 @@ const accents = [
 
 async function makeThemeObject(
   name: string,
-  accent: keyof Labels<Color, AlphaColor>,
-  palette: Labels<Color, AlphaColor>
+  accent: string,
+  flavor: CatppuccinFlavor,
 ) {
+  let themeAccent: string = "";
+  flavor.colorEntries.map(([colorName, { hex }]) => {
+    if (colorName == accent) {
+      themeAccent = hex;
+    }
+  });
+  const palette = flavor.colors;
   const themeName = `catppuccin-${name}-${accent}`;
-  const encodedName = new TextEncoder().encode(themeName)
+  const encodedName = new TextEncoder().encode(themeName);
   return {
     manifest_version: 2,
     name: themeName,
@@ -47,9 +53,9 @@ async function makeThemeObject(
         strict_min_version: "60.0",
       },
     },
-    description: `Soothing pastel theme for Thunderbird - ${titleCase(
-      name
-    )} ${titleCase(accent)}`,
+    description: `Soothing pastel theme for Thunderbird - ${titleCase(name)} ${
+      titleCase(accent)
+    }`,
     icons: {
       "16": "images/icon16.png",
       "48": "images/icon48.png",
@@ -71,11 +77,13 @@ async function makeThemeObject(
         layout_bg_1: "--layout-background-1",
         button_bg: "--button-background-color",
         lwt_accent_color: "--lwt-accent-color",
-        list_container_background_selected_current: "--list-container-background-selected-current",
+        list_container_background_selected_current:
+          "--list-container-background-selected-current",
         ab_cards_list_bg: "--ab-cards-list-bg",
         in_content_box_info_background: "--in-content-box-info-background",
         calendar_view_toggle_bg: "--calendar-view-toggle-background",
-        calendar_view_toggle_hover_bg: "--calendar-view-toggle-hover-background",
+        calendar_view_toggle_hover_bg:
+          "--calendar-view-toggle-hover-background",
         tabs_toolbar_bg: "--tabs-toolbar-background-color",
         color_gray_70: "--color-gray-70",
         color_gray_50: "--color-gray-50",
@@ -84,12 +92,12 @@ async function makeThemeObject(
     theme: {
       colors: {
         frame: palette.base.hex,
-        button_background_active: palette[accent].hex,
+        button_background_active: themeAccent,
         button_background_hover: palette.surface0.hex,
         icons: palette.text.hex,
         tab_text: palette.text.hex,
-        tab_line: palette[accent].hex,
-        tab_loading: palette[accent].hex,
+        tab_line: themeAccent,
+        tab_loading: themeAccent,
         tab_selected: palette.base.hex,
         tab_background_text: palette.overlay1.hex,
         tab_background_separator: palette.surface0.hex,
@@ -97,30 +105,220 @@ async function makeThemeObject(
         toolbar: palette.base.hex,
         toolbar_field: palette.surface0.hex,
         toolbar_field_text: palette.text.hex,
-        toolbar_field_highlight: palette[accent].hex,
+        toolbar_field_highlight: themeAccent,
         toolbar_field_highlight_text: palette.mantle.hex,
         toolbar_field_border: palette.mantle.hex,
         toolbar_field_focus: palette.surface0.hex,
         toolbar_field_text_focus: palette.text.hex,
-        toolbar_field_border_focus: palette[accent].hex,
+        toolbar_field_border_focus: themeAccent,
         toolbar_top_separator: palette.surface0.hex,
         toolbar_bottom_separator: palette.surface0.hex,
         toolbar_vertical_separator: palette.surface0.hex,
         sidebar: palette.base.hex,
         sidebar_text: palette.text.hex,
-        sidebar_highlight: palette[accent].hex,
+        sidebar_highlight: themeAccent,
         sidebar_highlight_text: palette.mantle.hex,
         sidebar_border: palette.surface0.hex,
         popup: palette.surface0.hex,
         popup_text: palette.text.hex,
         popup_border: palette.base.hex,
-        popup_highlight: palette[accent].hex,
+        popup_highlight: themeAccent,
         popup_highlight_text: palette.mantle.hex,
         spaces_bg: palette.mantle.hex,
         tree_view_bg: palette.crust.hex,
         bg_color: palette.base.hex,
-        spaces_bg_active: palette[accent].hex,
-        button_primary_bg: palette[accent].hex,
+        spaces_bg_active: themeAccent,
+        button_primary_bg: themeAccent,
+        button_text: palette.crust.hex,
+        spaces_button: palette.crust.hex,
+        tree_pane_bg: palette.crust.hex,
+        tree_card_bg: palette.mantle.hex,
+        layout_bg_0: palette.base.hex,
+        layout_bg_1: palette.base.hex,
+        button_bg: palette.mantle.hex,
+        lwt_accent_color: palette.mantle.hex,
+        list_container_background_selected_current: palette.mantle.hex,
+        ab_cards_list_bg: palette.mantle.hex,
+        in_content_box_info_background: palette.mantle.hex,
+        calendar_view_toggle_bg: palette.mantle.hex,
+        calendar_view_toggle_hover_bg: palette.surface0.hex,
+        tabs_toolbar_bg: palette.mantle.hex,
+        color_gray_70: palette.mantle.hex,
+        color_gray_50: palette.surface1.hex,
+      },
+    },
+  };
+}
+
+async function makeDarkLightThemeObject(
+  name: string,
+  accent: string,
+  flavor: CatppuccinFlavor,
+) {
+  let lightAccent: string = "";
+  let darkAccent: string = "";
+
+  if (flavor.dark) {
+    flavor.colorEntries.map(([colorName, { hex }]) => {
+      if (colorName == accent) {
+        darkAccent = hex;
+      }
+    });
+    flavors.latte.colorEntries.map(([colorName, { hex }]) => {
+      if (colorName == accent) {
+        lightAccent = hex;
+      }
+    });
+  } else return NaN;
+
+  const palette = flavor.colors;
+  const lightPalette = flavors.latte.colors;
+  const themeName = `catppuccin-${name}-${accent}`;
+  const encodedName = new TextEncoder().encode(themeName);
+  return {
+    manifest_version: 2,
+    name: themeName,
+    version: "1.0.0",
+    applications: {
+      gecko: {
+        id: `{${await uuid.v5.generate(NAMESPACE_URL, encodedName)}}`,
+        strict_min_version: "60.0",
+      },
+    },
+    description: `Soothing pastel theme for Thunderbird - Latte and ${
+      titleCase(name)
+    } ${titleCase(accent)}`,
+    icons: {
+      "16": "images/icon16.png",
+      "48": "images/icon48.png",
+      "128": "images/icon128.png",
+    },
+    theme_experiment: {
+      stylesheet: "styles.css",
+      colors: {
+        spaces_bg: "--spaces-bg-color",
+        spaces_bg_active: "--spaces-button-active-bg-color",
+        spaces_button: "--spaces-button-active-text-color",
+        tree_view_bg: "--tree-view-bg",
+        bg_color: "--bg-color",
+        button_primary_bg: "--button-primary-background-color",
+        button_text: "--button-primary-text-color",
+        tree_pane_bg: "--tree-pane-background",
+        tree_card_bg: "--tree-card-background",
+        layout_bg_0: "--layout-background-0",
+        layout_bg_1: "--layout-background-1",
+        button_bg: "--button-background-color",
+        lwt_accent_color: "--lwt-accent-color",
+        list_container_background_selected_current:
+          "--list-container-background-selected-current",
+        ab_cards_list_bg: "--ab-cards-list-bg",
+        in_content_box_info_background: "--in-content-box-info-background",
+        calendar_view_toggle_bg: "--calendar-view-toggle-background",
+        calendar_view_toggle_hover_bg:
+          "--calendar-view-toggle-hover-background",
+        tabs_toolbar_bg: "--tabs-toolbar-background-color",
+        color_gray_70: "--color-gray-70",
+        color_gray_50: "--color-gray-50",
+      },
+    },
+    theme: {
+      colors: {
+        frame: lightPalette.base.hex,
+        button_background_active: lightAccent,
+        button_background_hover: lightPalette.surface0.hex,
+        icons: lightPalette.text.hex,
+        tab_text: lightPalette.text.hex,
+        tab_line: lightAccent,
+        tab_loading: lightAccent,
+        tab_selected: lightPalette.base.hex,
+        tab_background_text: lightPalette.overlay1.hex,
+        tab_background_separator: lightPalette.surface0.hex,
+        bookmark_text: lightPalette.text.hex,
+        toolbar: lightPalette.base.hex,
+        toolbar_field: lightPalette.surface0.hex,
+        toolbar_field_text: lightPalette.text.hex,
+        toolbar_field_highlight: lightAccent,
+        toolbar_field_highlight_text: lightPalette.mantle.hex,
+        toolbar_field_border: lightPalette.mantle.hex,
+        toolbar_field_focus: lightPalette.surface0.hex,
+        toolbar_field_text_focus: lightPalette.text.hex,
+        toolbar_field_border_focus: lightAccent,
+        toolbar_top_separator: lightPalette.surface0.hex,
+        toolbar_bottom_separator: lightPalette.surface0.hex,
+        toolbar_vertical_separator: lightPalette.surface0.hex,
+        sidebar: lightPalette.base.hex,
+        sidebar_text: lightPalette.text.hex,
+        sidebar_highlight: lightAccent,
+        sidebar_highlight_text: lightPalette.mantle.hex,
+        sidebar_border: lightPalette.surface0.hex,
+        popup: lightPalette.surface0.hex,
+        popup_text: lightPalette.text.hex,
+        popup_border: lightPalette.base.hex,
+        popup_highlight: lightAccent,
+        popup_highlight_text: lightPalette.mantle.hex,
+        spaces_bg: lightPalette.mantle.hex,
+        tree_view_bg: lightPalette.crust.hex,
+        bg_color: lightPalette.base.hex,
+        spaces_bg_active: lightAccent,
+        button_primary_bg: lightAccent,
+        button_text: lightPalette.crust.hex,
+        spaces_button: lightPalette.crust.hex,
+        tree_pane_bg: lightPalette.crust.hex,
+        tree_card_bg: lightPalette.mantle.hex,
+        layout_bg_0: lightPalette.base.hex,
+        layout_bg_1: lightPalette.base.hex,
+        button_bg: lightPalette.mantle.hex,
+        lwt_accent_color: lightPalette.mantle.hex,
+        list_container_background_selected_current: lightPalette.mantle.hex,
+        ab_cards_list_bg: lightPalette.mantle.hex,
+        in_content_box_info_background: lightPalette.mantle.hex,
+        calendar_view_toggle_bg: lightPalette.mantle.hex,
+        calendar_view_toggle_hover_bg: lightPalette.surface0.hex,
+        tabs_toolbar_bg: lightPalette.mantle.hex,
+        color_gray_70: lightPalette.mantle.hex,
+        color_gray_50: lightPalette.surface1.hex,
+      },
+    },
+    dark_theme: {
+      colors: {
+        frame: palette.base.hex,
+        button_background_active: darkAccent,
+        button_background_hover: palette.surface0.hex,
+        icons: palette.text.hex,
+        tab_text: palette.text.hex,
+        tab_line: darkAccent,
+        tab_loading: darkAccent,
+        tab_selected: palette.base.hex,
+        tab_background_text: palette.overlay1.hex,
+        tab_background_separator: palette.surface0.hex,
+        bookmark_text: palette.text.hex,
+        toolbar: palette.base.hex,
+        toolbar_field: palette.surface0.hex,
+        toolbar_field_text: palette.text.hex,
+        toolbar_field_highlight: darkAccent,
+        toolbar_field_highlight_text: palette.mantle.hex,
+        toolbar_field_border: palette.mantle.hex,
+        toolbar_field_focus: palette.surface0.hex,
+        toolbar_field_text_focus: palette.text.hex,
+        toolbar_field_border_focus: darkAccent,
+        toolbar_top_separator: palette.surface0.hex,
+        toolbar_bottom_separator: palette.surface0.hex,
+        toolbar_vertical_separator: palette.surface0.hex,
+        sidebar: palette.base.hex,
+        sidebar_text: palette.text.hex,
+        sidebar_highlight: darkAccent,
+        sidebar_highlight_text: palette.mantle.hex,
+        sidebar_border: palette.surface0.hex,
+        popup: palette.surface0.hex,
+        popup_text: palette.text.hex,
+        popup_border: palette.base.hex,
+        popup_highlight: darkAccent,
+        popup_highlight_text: palette.mantle.hex,
+        spaces_bg: palette.mantle.hex,
+        tree_view_bg: palette.crust.hex,
+        bg_color: palette.base.hex,
+        spaces_bg_active: darkAccent,
+        button_primary_bg: darkAccent,
         button_text: palette.crust.hex,
         spaces_button: palette.crust.hex,
         tree_pane_bg: palette.crust.hex,
@@ -144,33 +342,44 @@ async function makeThemeObject(
 
 async function generateVariants(
   name: string,
-  palette: Labels<Color, AlphaColor>
+  flavor: CatppuccinFlavor,
 ) {
   for (const accent of accents) {
-    const theme = await makeThemeObject(name, accent, palette);
+    const theme = await makeThemeObject(name, accent, flavor);
+    const darkLightTheme = await makeDarkLightThemeObject(name, accent, flavor);
+    const fileName = `${name}-${accent}.xpi`;
+    writeTheme(fileName, theme, `./themes/${name}`);
+    writeTheme(fileName, darkLightTheme, `./themes/dark-light/${name}`);
+  }
+}
+
+async function writeTheme(
+  fileName: string,
+  theme: unknown,
+  path: string,
+) {
+  if (theme) {
     const json = JSON.stringify(theme, undefined, 2);
 
-    Deno.mkdirSync(`./themes/${name}`, {
+    Deno.mkdirSync(`${path}`, {
       recursive: true,
     });
 
     const zip = new JSZip();
     zip.addFile("manifest.json", json);
 
-    const images = zip.folder("images")
-    images.addFile("icon16.png", "./assets/icon16.png")
-    images.addFile("icon48.png", "./assets/icon48.png")
-    images.addFile("icon128.png", "./assets/icon128.png")
+    const images = zip.folder("images");
+    images.addFile("icon16.png", "./assets/icon16.png");
+    images.addFile("icon48.png", "./assets/icon48.png");
+    images.addFile("icon128.png", "./assets/icon128.png");
 
-    await zip.writeZip(`./themes/${name}/${name}-${accent}.xpi`);
+    await zip.writeZip(`${path}/${fileName}`);
   }
 }
 
 const start = performance.now();
 await Promise.all(
-  Object.entries(variants).map(([name, palette]) =>
-    generateVariants(name, palette)
-  )
+  flavorEntries.map(([name, flavor]) => generateVariants(name, flavor)),
 );
 
 console.log("Built in", performance.now() - start, "ms");

--- a/build.ts
+++ b/build.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env
 import {
+  AccentName,
   CatppuccinFlavor,
   flavorEntries,
   flavors,
-} from "https://deno.land/x/catppuccin@v1.7.1/mod.ts";
+} from "jsr:@catppuccin/palette@1.7.1";
 import { titleCase } from "https://deno.land/x/case@2.2.0/mod.ts";
 import { JSZip } from "https://deno.land/x/jszip@0.11.0/mod.ts";
 import * as uuid from "https://deno.land/std@0.207.0/uuid/mod.ts";
@@ -31,16 +32,26 @@ const accents = [
 
 async function makeThemeObject(
   name: string,
-  accent: string,
-  flavor: CatppuccinFlavor,
+  accent: AccentName,
+  palette: CatppuccinFlavor,
+  autoTheme: boolean,
 ) {
-  let themeAccent: string = "";
-  flavor.colorEntries.map(([colorName, { hex }]) => {
-    if (colorName == accent) {
-      themeAccent = hex;
+  const darkColors = await getColors(accent, palette);
+  let lightColors = await getColors(accent, palette);
+  let colorScheme = "dark";
+
+  if (!palette.dark) {
+    colorScheme = "light";
+  }
+
+  if (autoTheme) {
+    if (palette.name == flavors.latte.name) {
+      return null;
     }
-  });
-  const palette = flavor.colors;
+    lightColors = await getColors(accent, flavors.latte);
+    colorScheme = "auto";
+  }
+
   const themeName = `catppuccin-${name}-${accent}`;
   const encodedName = new TextEncoder().encode(themeName);
   return {
@@ -90,253 +101,79 @@ async function makeThemeObject(
       },
     },
     theme: {
-      colors: {
-        frame: palette.base.hex,
-        button_background_active: themeAccent,
-        button_background_hover: palette.surface0.hex,
-        icons: palette.text.hex,
-        tab_text: palette.text.hex,
-        tab_line: themeAccent,
-        tab_loading: themeAccent,
-        tab_selected: palette.base.hex,
-        tab_background_text: palette.overlay1.hex,
-        tab_background_separator: palette.surface0.hex,
-        bookmark_text: palette.text.hex,
-        toolbar: palette.base.hex,
-        toolbar_field: palette.surface0.hex,
-        toolbar_field_text: palette.text.hex,
-        toolbar_field_highlight: themeAccent,
-        toolbar_field_highlight_text: palette.mantle.hex,
-        toolbar_field_border: palette.mantle.hex,
-        toolbar_field_focus: palette.surface0.hex,
-        toolbar_field_text_focus: palette.text.hex,
-        toolbar_field_border_focus: themeAccent,
-        toolbar_top_separator: palette.surface0.hex,
-        toolbar_bottom_separator: palette.surface0.hex,
-        toolbar_vertical_separator: palette.surface0.hex,
-        sidebar: palette.base.hex,
-        sidebar_text: palette.text.hex,
-        sidebar_highlight: themeAccent,
-        sidebar_highlight_text: palette.mantle.hex,
-        sidebar_border: palette.surface0.hex,
-        popup: palette.surface0.hex,
-        popup_text: palette.text.hex,
-        popup_border: palette.base.hex,
-        popup_highlight: themeAccent,
-        popup_highlight_text: palette.mantle.hex,
-        spaces_bg: palette.mantle.hex,
-        tree_view_bg: palette.crust.hex,
-        bg_color: palette.base.hex,
-        spaces_bg_active: themeAccent,
-        button_primary_bg: themeAccent,
-        button_text: palette.crust.hex,
-        spaces_button: palette.crust.hex,
-        tree_pane_bg: palette.crust.hex,
-        tree_card_bg: palette.mantle.hex,
-        layout_bg_0: palette.base.hex,
-        layout_bg_1: palette.base.hex,
-        button_bg: palette.mantle.hex,
-        lwt_accent_color: palette.mantle.hex,
-        list_container_background_selected_current: palette.mantle.hex,
-        ab_cards_list_bg: palette.mantle.hex,
-        in_content_box_info_background: palette.mantle.hex,
-        calendar_view_toggle_bg: palette.mantle.hex,
-        calendar_view_toggle_hover_bg: palette.surface0.hex,
-        tabs_toolbar_bg: palette.mantle.hex,
-        color_gray_70: palette.mantle.hex,
-        color_gray_50: palette.surface1.hex,
+      colors: lightColors,
+      properties: {
+        color_scheme: colorScheme,
+      },
+    },
+    dark_theme: {
+      colors: darkColors,
+      properties: {
+        color_scheme: colorScheme,
       },
     },
   };
 }
 
-async function makeDarkLightThemeObject(
-  name: string,
-  accent: string,
-  flavor: CatppuccinFlavor,
+async function getColors(
+  accent: AccentName,
+  palette: CatppuccinFlavor,
 ) {
-  let lightAccent: string = "";
-  let darkAccent: string = "";
-
-  if (flavor.dark) {
-    flavor.colorEntries.map(([colorName, { hex }]) => {
-      if (colorName == accent) {
-        darkAccent = hex;
-      }
-    });
-    flavors.latte.colorEntries.map(([colorName, { hex }]) => {
-      if (colorName == accent) {
-        lightAccent = hex;
-      }
-    });
-  } else return NaN;
-
-  const palette = flavor.colors;
-  const lightPalette = flavors.latte.colors;
-  const themeName = `catppuccin-${name}-${accent}`;
-  const encodedName = new TextEncoder().encode(themeName);
   return {
-    manifest_version: 2,
-    name: themeName,
-    version: "1.0.0",
-    applications: {
-      gecko: {
-        id: `{${await uuid.v5.generate(NAMESPACE_URL, encodedName)}}`,
-        strict_min_version: "60.0",
-      },
-    },
-    description: `Soothing pastel theme for Thunderbird - Latte and ${
-      titleCase(name)
-    } ${titleCase(accent)}`,
-    icons: {
-      "16": "images/icon16.png",
-      "48": "images/icon48.png",
-      "128": "images/icon128.png",
-    },
-    theme_experiment: {
-      stylesheet: "styles.css",
-      colors: {
-        spaces_bg: "--spaces-bg-color",
-        spaces_bg_active: "--spaces-button-active-bg-color",
-        spaces_button: "--spaces-button-active-text-color",
-        tree_view_bg: "--tree-view-bg",
-        bg_color: "--bg-color",
-        button_primary_bg: "--button-primary-background-color",
-        button_text: "--button-primary-text-color",
-        tree_pane_bg: "--tree-pane-background",
-        tree_card_bg: "--tree-card-background",
-        layout_bg_0: "--layout-background-0",
-        layout_bg_1: "--layout-background-1",
-        button_bg: "--button-background-color",
-        lwt_accent_color: "--lwt-accent-color",
-        list_container_background_selected_current:
-          "--list-container-background-selected-current",
-        ab_cards_list_bg: "--ab-cards-list-bg",
-        in_content_box_info_background: "--in-content-box-info-background",
-        calendar_view_toggle_bg: "--calendar-view-toggle-background",
-        calendar_view_toggle_hover_bg:
-          "--calendar-view-toggle-hover-background",
-        tabs_toolbar_bg: "--tabs-toolbar-background-color",
-        color_gray_70: "--color-gray-70",
-        color_gray_50: "--color-gray-50",
-      },
-    },
-    theme: {
-      colors: {
-        frame: lightPalette.base.hex,
-        button_background_active: lightAccent,
-        button_background_hover: lightPalette.surface0.hex,
-        icons: lightPalette.text.hex,
-        tab_text: lightPalette.text.hex,
-        tab_line: lightAccent,
-        tab_loading: lightAccent,
-        tab_selected: lightPalette.base.hex,
-        tab_background_text: lightPalette.overlay1.hex,
-        tab_background_separator: lightPalette.surface0.hex,
-        bookmark_text: lightPalette.text.hex,
-        toolbar: lightPalette.base.hex,
-        toolbar_field: lightPalette.surface0.hex,
-        toolbar_field_text: lightPalette.text.hex,
-        toolbar_field_highlight: lightAccent,
-        toolbar_field_highlight_text: lightPalette.mantle.hex,
-        toolbar_field_border: lightPalette.mantle.hex,
-        toolbar_field_focus: lightPalette.surface0.hex,
-        toolbar_field_text_focus: lightPalette.text.hex,
-        toolbar_field_border_focus: lightAccent,
-        toolbar_top_separator: lightPalette.surface0.hex,
-        toolbar_bottom_separator: lightPalette.surface0.hex,
-        toolbar_vertical_separator: lightPalette.surface0.hex,
-        sidebar: lightPalette.base.hex,
-        sidebar_text: lightPalette.text.hex,
-        sidebar_highlight: lightAccent,
-        sidebar_highlight_text: lightPalette.mantle.hex,
-        sidebar_border: lightPalette.surface0.hex,
-        popup: lightPalette.surface0.hex,
-        popup_text: lightPalette.text.hex,
-        popup_border: lightPalette.base.hex,
-        popup_highlight: lightAccent,
-        popup_highlight_text: lightPalette.mantle.hex,
-        spaces_bg: lightPalette.mantle.hex,
-        tree_view_bg: lightPalette.crust.hex,
-        bg_color: lightPalette.base.hex,
-        spaces_bg_active: lightAccent,
-        button_primary_bg: lightAccent,
-        button_text: lightPalette.crust.hex,
-        spaces_button: lightPalette.crust.hex,
-        tree_pane_bg: lightPalette.crust.hex,
-        tree_card_bg: lightPalette.mantle.hex,
-        layout_bg_0: lightPalette.base.hex,
-        layout_bg_1: lightPalette.base.hex,
-        button_bg: lightPalette.mantle.hex,
-        lwt_accent_color: lightPalette.mantle.hex,
-        list_container_background_selected_current: lightPalette.mantle.hex,
-        ab_cards_list_bg: lightPalette.mantle.hex,
-        in_content_box_info_background: lightPalette.mantle.hex,
-        calendar_view_toggle_bg: lightPalette.mantle.hex,
-        calendar_view_toggle_hover_bg: lightPalette.surface0.hex,
-        tabs_toolbar_bg: lightPalette.mantle.hex,
-        color_gray_70: lightPalette.mantle.hex,
-        color_gray_50: lightPalette.surface1.hex,
-      },
-    },
-    dark_theme: {
-      colors: {
-        frame: palette.base.hex,
-        button_background_active: darkAccent,
-        button_background_hover: palette.surface0.hex,
-        icons: palette.text.hex,
-        tab_text: palette.text.hex,
-        tab_line: darkAccent,
-        tab_loading: darkAccent,
-        tab_selected: palette.base.hex,
-        tab_background_text: palette.overlay1.hex,
-        tab_background_separator: palette.surface0.hex,
-        bookmark_text: palette.text.hex,
-        toolbar: palette.base.hex,
-        toolbar_field: palette.surface0.hex,
-        toolbar_field_text: palette.text.hex,
-        toolbar_field_highlight: darkAccent,
-        toolbar_field_highlight_text: palette.mantle.hex,
-        toolbar_field_border: palette.mantle.hex,
-        toolbar_field_focus: palette.surface0.hex,
-        toolbar_field_text_focus: palette.text.hex,
-        toolbar_field_border_focus: darkAccent,
-        toolbar_top_separator: palette.surface0.hex,
-        toolbar_bottom_separator: palette.surface0.hex,
-        toolbar_vertical_separator: palette.surface0.hex,
-        sidebar: palette.base.hex,
-        sidebar_text: palette.text.hex,
-        sidebar_highlight: darkAccent,
-        sidebar_highlight_text: palette.mantle.hex,
-        sidebar_border: palette.surface0.hex,
-        popup: palette.surface0.hex,
-        popup_text: palette.text.hex,
-        popup_border: palette.base.hex,
-        popup_highlight: darkAccent,
-        popup_highlight_text: palette.mantle.hex,
-        spaces_bg: palette.mantle.hex,
-        tree_view_bg: palette.crust.hex,
-        bg_color: palette.base.hex,
-        spaces_bg_active: darkAccent,
-        button_primary_bg: darkAccent,
-        button_text: palette.crust.hex,
-        spaces_button: palette.crust.hex,
-        tree_pane_bg: palette.crust.hex,
-        tree_card_bg: palette.mantle.hex,
-        layout_bg_0: palette.base.hex,
-        layout_bg_1: palette.base.hex,
-        button_bg: palette.mantle.hex,
-        lwt_accent_color: palette.mantle.hex,
-        list_container_background_selected_current: palette.mantle.hex,
-        ab_cards_list_bg: palette.mantle.hex,
-        in_content_box_info_background: palette.mantle.hex,
-        calendar_view_toggle_bg: palette.mantle.hex,
-        calendar_view_toggle_hover_bg: palette.surface0.hex,
-        tabs_toolbar_bg: palette.mantle.hex,
-        color_gray_70: palette.mantle.hex,
-        color_gray_50: palette.surface1.hex,
-      },
-    },
+    frame: palette.colors.base.hex,
+    button_background_active: palette.colors[accent].hex,
+    button_background_hover: palette.colors.surface0.hex,
+    icons: palette.colors.text.hex,
+    tab_text: palette.colors.text.hex,
+    tab_line: palette.colors[accent].hex,
+    tab_loading: palette.colors[accent].hex,
+    tab_selected: palette.colors.base.hex,
+    tab_background_text: palette.colors.overlay1.hex,
+    tab_background_separator: palette.colors.surface0.hex,
+    bookmark_text: palette.colors.text.hex,
+    toolbar: palette.colors.base.hex,
+    toolbar_field: palette.colors.surface0.hex,
+    toolbar_field_text: palette.colors.text.hex,
+    toolbar_field_highlight: palette.colors[accent].hex,
+    toolbar_field_highlight_text: palette.colors.mantle.hex,
+    toolbar_field_border: palette.colors.mantle.hex,
+    toolbar_field_focus: palette.colors.surface0.hex,
+    toolbar_field_text_focus: palette.colors.text.hex,
+    toolbar_field_border_focus: palette.colors[accent].hex,
+    toolbar_top_separator: palette.colors.surface0.hex,
+    toolbar_bottom_separator: palette.colors.surface0.hex,
+    toolbar_vertical_separator: palette.colors.surface0.hex,
+    sidebar: palette.colors.base.hex,
+    sidebar_text: palette.colors.text.hex,
+    sidebar_highlight: palette.colors[accent].hex,
+    sidebar_highlight_text: palette.colors.mantle.hex,
+    sidebar_border: palette.colors.surface0.hex,
+    popup: palette.colors.surface0.hex,
+    popup_text: palette.colors.text.hex,
+    popup_border: palette.colors.base.hex,
+    popup_highlight: palette.colors[accent].hex,
+    popup_highlight_text: palette.colors.mantle.hex,
+    spaces_bg: palette.colors.mantle.hex,
+    tree_view_bg: palette.colors.crust.hex,
+    bg_color: palette.colors.base.hex,
+    spaces_bg_active: palette.colors[accent].hex,
+    button_primary_bg: palette.colors[accent].hex,
+    button_text: palette.colors.crust.hex,
+    spaces_button: palette.colors.crust.hex,
+    tree_pane_bg: palette.colors.crust.hex,
+    tree_card_bg: palette.colors.mantle.hex,
+    layout_bg_0: palette.colors.base.hex,
+    layout_bg_1: palette.colors.base.hex,
+    button_bg: palette.colors.mantle.hex,
+    lwt_accent_color: palette.colors.mantle.hex,
+    list_container_background_selected_current: palette.colors.mantle.hex,
+    ab_cards_list_bg: palette.colors.mantle.hex,
+    in_content_box_info_background: palette.colors.mantle.hex,
+    calendar_view_toggle_bg: palette.colors.mantle.hex,
+    calendar_view_toggle_hover_bg: palette.colors.surface0.hex,
+    tabs_toolbar_bg: palette.colors.mantle.hex,
+    color_gray_70: palette.colors.mantle.hex,
+    color_gray_50: palette.colors.surface1.hex,
   };
 }
 
@@ -345,11 +182,11 @@ async function generateVariants(
   flavor: CatppuccinFlavor,
 ) {
   for (const accent of accents) {
-    const theme = await makeThemeObject(name, accent, flavor);
-    const darkLightTheme = await makeDarkLightThemeObject(name, accent, flavor);
+    const theme = await makeThemeObject(name, accent, flavor, false);
+    const autoTheme = await makeThemeObject(name, accent, flavor, true);
     const fileName = `${name}-${accent}.xpi`;
-    writeTheme(fileName, theme, `./themes/${name}`);
-    writeTheme(fileName, darkLightTheme, `./themes/dark-light/${name}`);
+    writeTheme(fileName, theme, `./themes/default/${name}`);
+    writeTheme(fileName, autoTheme, `./themes/auto/${name}`);
   }
 }
 

--- a/build.ts
+++ b/build.ts
@@ -33,22 +33,22 @@ const accents = [
 async function makeThemeObject(
   identifier: string,
   accent: AccentName,
-  palette: CatppuccinFlavor,
+  flavor: CatppuccinFlavor,
   autoTheme: boolean,
 ) {
-  const darkColors = await getColors(accent, palette);
-  let lightColors = await getColors(accent, palette);
+  const darkColors = getColors(accent, flavor);
+  let lightColors = getColors(accent, flavor);
   let colorScheme = "dark";
 
-  if (!palette.dark) {
+  if (!flavor.dark) {
     colorScheme = "light";
   }
 
   if (autoTheme) {
-    if (palette.name == flavors.latte.name) {
+    if (flavor.name == flavors.latte.name) {
       return null;
     }
-    lightColors = await getColors(accent, flavors.latte);
+    lightColors = getColors(accent, flavors.latte);
     colorScheme = "auto";
   }
 
@@ -64,7 +64,7 @@ async function makeThemeObject(
         strict_min_version: "60.0",
       },
     },
-    description: `Soothing pastel theme for Thunderbird - ${titleCase(palette.name)} ${
+    description: `Soothing pastel theme for Thunderbird - ${titleCase(flavor.name)} ${
       titleCase(accent)
     }`,
     icons: {
@@ -115,65 +115,65 @@ async function makeThemeObject(
   };
 }
 
-async function getColors(
+function getColors(
   accent: AccentName,
-  palette: CatppuccinFlavor,
+  flavor: CatppuccinFlavor,
 ) {
   return {
-    frame: palette.colors.base.hex,
-    button_background_active: palette.colors[accent].hex,
-    button_background_hover: palette.colors.surface0.hex,
-    icons: palette.colors.text.hex,
-    tab_text: palette.colors.text.hex,
-    tab_line: palette.colors[accent].hex,
-    tab_loading: palette.colors[accent].hex,
-    tab_selected: palette.colors.base.hex,
-    tab_background_text: palette.colors.overlay1.hex,
-    tab_background_separator: palette.colors.surface0.hex,
-    bookmark_text: palette.colors.text.hex,
-    toolbar: palette.colors.base.hex,
-    toolbar_field: palette.colors.surface0.hex,
-    toolbar_field_text: palette.colors.text.hex,
-    toolbar_field_highlight: palette.colors[accent].hex,
-    toolbar_field_highlight_text: palette.colors.mantle.hex,
-    toolbar_field_border: palette.colors.mantle.hex,
-    toolbar_field_focus: palette.colors.surface0.hex,
-    toolbar_field_text_focus: palette.colors.text.hex,
-    toolbar_field_border_focus: palette.colors[accent].hex,
-    toolbar_top_separator: palette.colors.surface0.hex,
-    toolbar_bottom_separator: palette.colors.surface0.hex,
-    toolbar_vertical_separator: palette.colors.surface0.hex,
-    sidebar: palette.colors.base.hex,
-    sidebar_text: palette.colors.text.hex,
-    sidebar_highlight: palette.colors[accent].hex,
-    sidebar_highlight_text: palette.colors.mantle.hex,
-    sidebar_border: palette.colors.surface0.hex,
-    popup: palette.colors.surface0.hex,
-    popup_text: palette.colors.text.hex,
-    popup_border: palette.colors.base.hex,
-    popup_highlight: palette.colors[accent].hex,
-    popup_highlight_text: palette.colors.mantle.hex,
-    spaces_bg: palette.colors.mantle.hex,
-    tree_view_bg: palette.colors.crust.hex,
-    bg_color: palette.colors.base.hex,
-    spaces_bg_active: palette.colors[accent].hex,
-    button_primary_bg: palette.colors[accent].hex,
-    button_text: palette.colors.crust.hex,
-    spaces_button: palette.colors.crust.hex,
-    tree_pane_bg: palette.colors.crust.hex,
-    tree_card_bg: palette.colors.mantle.hex,
-    layout_bg_0: palette.colors.base.hex,
-    layout_bg_1: palette.colors.base.hex,
-    button_bg: palette.colors.mantle.hex,
-    lwt_accent_color: palette.colors.mantle.hex,
-    list_container_background_selected_current: palette.colors.mantle.hex,
-    ab_cards_list_bg: palette.colors.mantle.hex,
-    in_content_box_info_background: palette.colors.mantle.hex,
-    calendar_view_toggle_bg: palette.colors.mantle.hex,
-    calendar_view_toggle_hover_bg: palette.colors.surface0.hex,
-    tabs_toolbar_bg: palette.colors.mantle.hex,
-    color_gray_70: palette.colors.mantle.hex,
-    color_gray_50: palette.colors.surface1.hex,
+    frame: flavor.colors.base.hex,
+    button_background_active: flavor.colors[accent].hex,
+    button_background_hover: flavor.colors.surface0.hex,
+    icons: flavor.colors.text.hex,
+    tab_text: flavor.colors.text.hex,
+    tab_line: flavor.colors[accent].hex,
+    tab_loading: flavor.colors[accent].hex,
+    tab_selected: flavor.colors.base.hex,
+    tab_background_text: flavor.colors.overlay1.hex,
+    tab_background_separator: flavor.colors.surface0.hex,
+    bookmark_text: flavor.colors.text.hex,
+    toolbar: flavor.colors.base.hex,
+    toolbar_field: flavor.colors.surface0.hex,
+    toolbar_field_text: flavor.colors.text.hex,
+    toolbar_field_highlight: flavor.colors[accent].hex,
+    toolbar_field_highlight_text: flavor.colors.mantle.hex,
+    toolbar_field_border: flavor.colors.mantle.hex,
+    toolbar_field_focus: flavor.colors.surface0.hex,
+    toolbar_field_text_focus: flavor.colors.text.hex,
+    toolbar_field_border_focus: flavor.colors[accent].hex,
+    toolbar_top_separator: flavor.colors.surface0.hex,
+    toolbar_bottom_separator: flavor.colors.surface0.hex,
+    toolbar_vertical_separator: flavor.colors.surface0.hex,
+    sidebar: flavor.colors.base.hex,
+    sidebar_text: flavor.colors.text.hex,
+    sidebar_highlight: flavor.colors[accent].hex,
+    sidebar_highlight_text: flavor.colors.mantle.hex,
+    sidebar_border: flavor.colors.surface0.hex,
+    popup: flavor.colors.surface0.hex,
+    popup_text: flavor.colors.text.hex,
+    popup_border: flavor.colors.base.hex,
+    popup_highlight: flavor.colors[accent].hex,
+    popup_highlight_text: flavor.colors.mantle.hex,
+    spaces_bg: flavor.colors.mantle.hex,
+    tree_view_bg: flavor.colors.crust.hex,
+    bg_color: flavor.colors.base.hex,
+    spaces_bg_active: flavor.colors[accent].hex,
+    button_primary_bg: flavor.colors[accent].hex,
+    button_text: flavor.colors.crust.hex,
+    spaces_button: flavor.colors.crust.hex,
+    tree_pane_bg: flavor.colors.crust.hex,
+    tree_card_bg: flavor.colors.mantle.hex,
+    layout_bg_0: flavor.colors.base.hex,
+    layout_bg_1: flavor.colors.base.hex,
+    button_bg: flavor.colors.mantle.hex,
+    lwt_accent_color: flavor.colors.mantle.hex,
+    list_container_background_selected_current: flavor.colors.mantle.hex,
+    ab_cards_list_bg: flavor.colors.mantle.hex,
+    in_content_box_info_background: flavor.colors.mantle.hex,
+    calendar_view_toggle_bg: flavor.colors.mantle.hex,
+    calendar_view_toggle_hover_bg: flavor.colors.surface0.hex,
+    tabs_toolbar_bg: flavor.colors.mantle.hex,
+    color_gray_70: flavor.colors.mantle.hex,
+    color_gray_50: flavor.colors.surface1.hex,
   };
 }
 

--- a/build.ts
+++ b/build.ts
@@ -12,6 +12,36 @@ import * as uuid from "https://deno.land/std@0.207.0/uuid/mod.ts";
 // DO NOT CHANGE
 const NAMESPACE_URL = "6da2d448-69ec-48e0-aabf-3c6379788110";
 
+type ThemeObject = {
+  manifest_version: number;
+  name: string;
+  version: string;
+  applications: {
+    gecko: {
+      id: string;
+      strict_min_version: string;
+    };
+  };
+  description: string;
+  icons: Record<string, string>;
+  theme_experiment: {
+    stylesheet: string;
+    colors: Record<string, string>;
+  };
+  theme: {
+    colors: Record<string, string>;
+    properties: {
+      color_scheme: string;
+    };
+  };
+  dark_theme: {
+    colors: Record<string, string>;
+    properties: {
+      color_scheme: string;
+    };
+  };
+};
+
 const accents = [
   "rosewater",
   "flamingo",
@@ -34,7 +64,7 @@ async function makeThemeObject(
   accent: AccentName,
   flavor: CatppuccinFlavor,
   autoTheme: boolean,
-) {
+): Promise<ThemeObject> {
   const darkColors = getColors(accent, flavor);
   let lightColors = getColors(accent, flavor);
   let colorScheme = "dark";
@@ -114,7 +144,7 @@ async function makeThemeObject(
 function getColors(
   accent: AccentName,
   flavor: CatppuccinFlavor,
-) {
+): Record<string, string> {
   return {
     frame: flavor.colors.base.hex,
     button_background_active: flavor.colors[accent].hex,
@@ -190,7 +220,7 @@ async function generateVariants(
 
 async function writeTheme(
   fileName: string,
-  theme: unknown,
+  theme: ThemeObject,
   path: string,
 ) {
   const json = JSON.stringify(theme, undefined, 2);


### PR DESCRIPTION
Added another build file to build theme variants consisting of the light theme latte plus the `dark_theme` variants.

The variants are safely written to `themes/dark-light/.`

The `dark_theme` manifest property respects the system setting of preferring dark or light themes and switches the theme immediately once either option is changed.

See [here](https://webextension-api.thunderbird.net/en/beta-mv2/theme.html#manifest-file-properties) for reference.

Finally I think it's a great idea to have a separate build option here, but to not mix the two, as there are a few disadvantages as well, eg.of having to rely on the `prefer-dark` value, or else being forced to use the latte theme.